### PR TITLE
Faster segmentaion map creation

### DIFF
--- a/scripts/mkstar_image_grid.py
+++ b/scripts/mkstar_image_grid.py
@@ -170,12 +170,11 @@ if args.mkdirect == 'y':
         start_seg = time() #! TIMING
         selseg = sp > thresh
         full_seg[xp+pad-fov_pixels:xp+pad+fov_pixels,yp+pad-fov_pixels:yp+pad+fov_pixels][selseg] = i+1
-        end_seg = time() #! TIMING
         N += 1
         if N//10 == N/10:
             print(N,Ntot,len(np.unique(full_seg)),i+1)
-
-        cumulative_psf += (end_psf - start_psf) #! TIMING
+        end_seg = time() #! TIMING
+        cumulative_psf += (end_psf - start_psf)
         cumulative_seg += (end_seg - start_seg)
     
     end_postage = time() #! TIMING

--- a/scripts/mkstar_image_grid.py
+++ b/scripts/mkstar_image_grid.py
@@ -18,6 +18,7 @@ UserWarning: No thermal tables found, no thermal calculations can be performed. 
 
 '''
 from time import time
+from tqdm import tqdm
 
 start = time() #! TIMING
 
@@ -148,7 +149,7 @@ if args.mkdirect == 'y':
     cumulative_psf = 0
     cumulative_seg = 0
 
-    for i in range(0,len(stars00)):
+    for i in tqdm(range(0,len(stars00))):
         xpos = stars00[i]['Xpos']
         ypos = stars00[i]['Ypos']
         mag = stars00[i]['magnitude']
@@ -170,10 +171,12 @@ if args.mkdirect == 'y':
         start_seg = time() #! TIMING
         selseg = sp > thresh
         full_seg[xp+pad-fov_pixels:xp+pad+fov_pixels,yp+pad-fov_pixels:yp+pad+fov_pixels][selseg] = i+1
-        N += 1
-        if N//10 == N/10:
-            print(N,Ntot,len(np.unique(full_seg)),i+1)
         end_seg = time() #! TIMING
+
+        # N += 1
+        # if N//10 == N/10:
+        #     print(N,Ntot,len(np.unique(full_seg)),i+1)
+
         cumulative_psf += (end_psf - start_psf)
         cumulative_seg += (end_seg - start_seg)
     


### PR DESCRIPTION
Simplified and sped up segmentation map creation step, added timing statements, and replaced direct image print statements to tqdm progress bar. Total speed up on the cumulatvie segmentation map creation: 90s ->  >1s.

<img width="210" alt="Screenshot 2025-04-06 at 8 26 39 PM" src="https://github.com/user-attachments/assets/41638608-fe4b-4dc1-a142-c39e002d8e78" />